### PR TITLE
added build.yml for pypi-publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,57 @@
+name: Publish Python Package
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ '3.8' ]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+
+    - name: Install dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        python3 -m pip install setuptools build wheel numpy auditwheel patchelf
+
+    - name: Build package
+      run: |
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+        cmake --build build --config Release
+        cd python
+        python3 -m build --wheel -n
+
+    - name: Repair wheel
+      run: |
+        mkdir -p dist
+        cd python
+        auditwheel repair dist/*.whl --plat manylinux_2_34_x86_64
+        rm dist/*.whl
+        mv wheelhouse/*.whl ../dist/
+
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,6 @@ jobs:
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        repository-url: https://test.pypi.org/legacy/
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+#        repository-url: https://test.pypi.org/legacy/  # remove/comment line when publishing to actual repository
+        user: __token__                                # used before setting up a trusted publisher
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8' ]
+        python-version: [ '3.8', '3.10', '3.12' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/python/setup.py
+++ b/python/setup.py
@@ -36,7 +36,7 @@ def main():
         name="giskard_qpswift",
         version="1.0.0",
         description="Python interface for qpSWIFT",
-        long_description='qpSWIFT is light-weight sparse Quadratic Programming solver targetted for embedded and robotic applications. It employs Primal-Dual Interioir Point method with Mehrotra Predictor corrector step and Nesterov Todd scaling. For solving the linear system of equations, sparse LDL\' factorization is used along with approximate minimum degree heuristic to minimize fill-in of the factorizations. This is a fork of the official qpSWIFT project (https://github.com/qpSWIFT/qpSWIFT)',
+        long_description='qpSWIFT is light-weight sparse Quadratic Programming solver targetted for embedded and robotic applications. It employs Primal-Dual Interioir Point method with Mehrotra Predictor corrector step and Nesterov Todd scaling. For solving the linear system of equations, sparse LDL\' factorization is used along with approximate minimum degree heuristic to minimize fill-in of the factorizations.\n This is a fork of the official qpSWIFT project (https://github.com/qpSWIFT/qpSWIFT) adapted for use with Giskard(py)',
         url='https://github.com/SemRoCo/qpSWIFT',
         author="Simon Stelter",
         setup_requires=["numpy >= 1.6"],
@@ -46,7 +46,7 @@ def main():
         license_files=('LICENSE',),
         classifiers=[
             'Development Status :: 5 - Production/Stable',
-            'License :: OSI Approved :: GNU General Public License v3 (GPLv3)'
+            'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
             'Operating System :: POSIX :: Linux',
             'Intended Audience :: Science/Research',
             "Programming Language :: Python",

--- a/python/setup.py
+++ b/python/setup.py
@@ -31,10 +31,10 @@ _qpSWIFT = Extension("qpSWIFT",
 
 def main():
     setup(
-    name="qpSWIFT",
+    name="giskard_qpSWIFT",
     version="1.0.0",
     description="Python interface for qpSWIFT",
-    author="Abhishek Pandala",
+    author="",
     setup_requires=["numpy >= 1.6"],
     install_requires=["numpy >= 1.6"],
     ext_modules=[_qpSWIFT]

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,44 +1,61 @@
 from distutils.core import setup, Extension
+
 import numpy as np
 
 _qpSWIFT = Extension("qpSWIFT",
-    sources= [
-    "pyqpSWIFT.c",
-    "../src/amd_1.c",
-    "../src/amd_2.c",
-    "../src/amd_aat.c",
-    "../src/amd_control.c",
-    "../src/amd_defaults.c",
-    "../src/amd_dump.c",
-    "../src/amd_global.c",
-    "../src/amd_info.c",
-    "../src/amd_order.c",
-    "../src/amd_post_tree.c",
-    "../src/amd_postorder.c",
-    "../src/amd_preprocess.c",
-    "../src/amd_valid.c",
-    "../src/ldl.c",
-    "../src/timer.c",
-    "../src/Auxilary.c",
-    "../src/qpSWIFT.c" 
-    ],
-    include_dirs=["../include/",
-    np.get_include(),
-    ],
-#    extra_compile_args=["-O3"
-#    ]
-    )
+                     sources=[
+                         "pyqpSWIFT.c",
+                         "../src/amd_1.c",
+                         "../src/amd_2.c",
+                         "../src/amd_aat.c",
+                         "../src/amd_control.c",
+                         "../src/amd_defaults.c",
+                         "../src/amd_dump.c",
+                         "../src/amd_global.c",
+                         "../src/amd_info.c",
+                         "../src/amd_order.c",
+                         "../src/amd_post_tree.c",
+                         "../src/amd_postorder.c",
+                         "../src/amd_preprocess.c",
+                         "../src/amd_valid.c",
+                         "../src/ldl.c",
+                         "../src/timer.c",
+                         "../src/Auxilary.c",
+                         "../src/qpSWIFT.c"
+                     ],
+                     include_dirs=["../include/",
+                                   np.get_include(),
+                                   ],
+                     #    extra_compile_args=["-O3"
+                     #    ]
+                     )
+
 
 def main():
     setup(
-    name="giskard_qpswift",
-    version="1.0.0",
-    description="Python interface for qpSWIFT",
-    author="",
-    setup_requires=["numpy >= 1.6"],
-    install_requires=["numpy >= 1.6"],
-    ext_modules=[_qpSWIFT]
+        name="giskard_qpswift",
+        version="1.0.0",
+        description="Python interface for qpSWIFT",
+        long_description='qpSWIFT is light-weight sparse Quadratic Programming solver targetted for embedded and robotic applications. It employs Primal-Dual Interioir Point method with Mehrotra Predictor corrector step and Nesterov Todd scaling. For solving the linear system of equations, sparse LDL\' factorization is used along with approximate minimum degree heuristic to minimize fill-in of the factorizations. This is a fork of the official qpSWIFT project (https://github.com/qpSWIFT/qpSWIFT)',
+        url='https://github.com/SemRoCo/qpSWIFT',
+        author="Simon Stelter",
+        setup_requires=["numpy >= 1.6"],
+        install_requires=["numpy >= 1.6"],
+        ext_modules=[_qpSWIFT],
+        license='GPLv3',
+        license_files=('LICENSE',),
+        classifiers=[
+            'Development Status :: 5 - Production/Stable',
+            'License :: OSI Approved :: GNU General Public License v3 (GPLv3)'
+            'Operating System :: POSIX :: Linux',
+            'Intended Audience :: Science/Research',
+            "Programming Language :: Python",
+            'Programming Language :: Python :: 3.8',
+            'Programming Language :: Python :: 3.10',
+            'Programming Language :: Python :: 3.12',
+        ],
     )
+
 
 if __name__ == "__main__":
     main()

--- a/python/setup.py
+++ b/python/setup.py
@@ -31,7 +31,7 @@ _qpSWIFT = Extension("qpSWIFT",
 
 def main():
     setup(
-    name="giskard_qpSWIFT",
+    name="giskard_qpswift",
     version="1.0.0",
     description="Python interface for qpSWIFT",
     author="",


### PR DESCRIPTION
- added build.yml for automated pypi-publishing;
- new versions will require updated version tag in setup.py e.g. 1.0.1, otherwise the files can't be uploaded;
- upload requires a pypi-account and api-key secret in github-actions named PYPI_API_TOKEN ;
- test.pypi example package: https://test.pypi.org/project/giskard-qpswift/ ;
- trusted publisher can be setup after first publish of project (guide: https://docs.pypi.org/trusted-publishers/adding-a-publisher/);
- https://pypi.org/account/register/ for creating an account.